### PR TITLE
ci: :green_heart: add conditions to test ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,8 @@ jobs:
         uses: denolib/setup-deno@master
         with:
           deno-version: ${{ matrix.deno }} # tests across multiple Deno versions
+        continue-on-error: true # should be caught by the if-condition on the next step
 
       - name: Run Tests
+        if: ${{ success() }} # require the setup to run correctly
         run: deno test -A --unstable


### PR DESCRIPTION
Adds conditions and sets continue-on-error in an attempt to prevent problems with the setup script from being marked as testing failures.

Should fix #36 but requires testing.