### PR TITLE
`npm`/`yarn` packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 testcases.json
+dist/*
+deno

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+*
+!dist
+!LICENSE
+!package.json
+!README.md

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,5 @@
 *
-!dist
+!dist/*
 !LICENSE
 !package.json
 !README.md

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@OWNER:registry=https://npm.pkg.github.com

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@OWNER:registry=https://npm.pkg.github.com

--- a/makefile
+++ b/makefile
@@ -1,0 +1,13 @@
+all : dist/classic-api.ts dist/ratlog.ts
+
+# Download the latest version of Deno
+deno :
+	wget -nv --spider --output-file=wget_log https://github.com/denoland/deno/releases/latest
+	wget -q https://github.com/denoland/deno/releases/download/$(shell grep -Po v\\d+\\.\\d+\\.\\d+ wget_log)/deno-x86_64-unknown-linux-gnu.zip
+	unzip deno-x86_64-unknown-linux-gnu.zip
+	rm wget_log deno-x86_64-unknown-linux-gnu.zip
+
+# Bundle typescript files into safe outputs using Deno, which'll be fetched if needed
+dist/%.ts : deno *.ts
+	mkdir -p dist
+	./deno bundle $< $@

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-all : dist/classic-api.js dist/ratlog.js dist/ratlog.d.ts
+all : dist/classic-api.js dist/classic-api.d.ts dist/ratlog.js dist/ratlog.d.ts
 
 # Download the latest version of Deno
 deno :
@@ -8,10 +8,11 @@ deno :
 	@rm wget_log deno-x86_64-unknown-linux-gnu.zip
 
 # Bundle typescript files into safe outputs using Deno, which'll be fetched if needed
-dist/%.js : %.ts | deno
+dist/%.js : %.ts *.ts | deno
 	@mkdir -p dist
 	deno bundle $< $@
 
-dist/%.d.ts : %.ts
+# Generate typings, ignoring errors
+dist/%.d.ts : %.ts *.ts
 	@mkdir -p dist
 	-tsc $< --declaration --emitDeclarationOnly --outDir dist --lib esnext

--- a/makefile
+++ b/makefile
@@ -3,11 +3,11 @@ all : dist/classic-api.ts dist/ratlog.ts
 # Download the latest version of Deno
 deno :
 	wget -nv --spider --output-file=wget_log https://github.com/denoland/deno/releases/latest
-	wget -q https://github.com/denoland/deno/releases/download/$(shell grep -Po v\\d+\\.\\d+\\.\\d+ wget_log)/deno-x86_64-unknown-linux-gnu.zip
+	wget -q https://github.com/denoland/deno/releases/download/$$(grep -Po v\\d+\\.\\d+\\.\\d+ wget_log)/deno-x86_64-unknown-linux-gnu.zip
 	unzip deno-x86_64-unknown-linux-gnu.zip
 	rm wget_log deno-x86_64-unknown-linux-gnu.zip
 
 # Bundle typescript files into safe outputs using Deno, which'll be fetched if needed
-dist/%.ts : deno *.ts
+dist/%.ts : %.ts | deno
 	mkdir -p dist
-	./deno bundle $< $@
+	deno bundle $< $@

--- a/makefile
+++ b/makefile
@@ -1,13 +1,17 @@
-all : dist/classic-api.js dist/ratlog.js
+all : dist/classic-api.js dist/ratlog.js dist/ratlog.d.ts
 
 # Download the latest version of Deno
 deno :
 	wget -nv --spider --output-file=wget_log https://github.com/denoland/deno/releases/latest
 	wget -q https://github.com/denoland/deno/releases/download/$$(grep -Po v\\d+\\.\\d+\\.\\d+ wget_log)/deno-x86_64-unknown-linux-gnu.zip
 	unzip deno-x86_64-unknown-linux-gnu.zip
-	rm wget_log deno-x86_64-unknown-linux-gnu.zip
+	@rm wget_log deno-x86_64-unknown-linux-gnu.zip
 
 # Bundle typescript files into safe outputs using Deno, which'll be fetched if needed
 dist/%.js : %.ts | deno
-	mkdir -p dist
+	@mkdir -p dist
 	deno bundle $< $@
+
+dist/%.d.ts : %.ts
+	@mkdir -p dist
+	-tsc $< --declaration --emitDeclarationOnly --outDir dist --lib esnext

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-all : dist/classic-api.ts dist/ratlog.ts
+all : dist/classic-api.js dist/ratlog.js
 
 # Download the latest version of Deno
 deno :
@@ -8,6 +8,6 @@ deno :
 	rm wget_log deno-x86_64-unknown-linux-gnu.zip
 
 # Bundle typescript files into safe outputs using Deno, which'll be fetched if needed
-dist/%.ts : %.ts | deno
+dist/%.js : %.ts | deno
 	mkdir -p dist
 	deno bundle $< $@

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@legowerewolf/ratlog-deno",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"description": "Application Logging for Rats, Humans, and Machines",
 	"main": "index.js",
 	"repository": "git://github.com/legowerewolf/ratlog-deno.git",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,13 @@
 	"version": "1.1.3",
 	"description": "Application Logging for Rats, Humans, and Machines",
 	"main": "index.js",
-	"repository": "https://github.com/legowerewolf/ratlog-deno",
+	"repository": "git://github.com/legowerewolf/ratlog-deno.git",
 	"author": "Duncan Gibson <legowerewolf@gmail.com>",
 	"license": "MPL-2.0",
 	"scripts": {
 		"prepublish": "make all"
+	},
+	"publishConfig": {
+		"registry": "https://npm.pkg.github.com"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "@legowerewolf/ratlog-deno",
+	"version": "1.1.3",
+	"description": "Application Logging for Rats, Humans, and Machines",
+	"main": "index.js",
+	"repository": "https://github.com/legowerewolf/ratlog-deno",
+	"author": "Duncan Gibson <legowerewolf@gmail.com>",
+	"license": "MPL-2.0",
+	"scripts": {
+		"build": "make all"
+	}
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
 	"author": "Duncan Gibson <legowerewolf@gmail.com>",
 	"license": "MPL-2.0",
 	"scripts": {
-		"build": "make all"
+		"prepublish": "make all"
 	}
 }


### PR DESCRIPTION
Present state: on `npm publish`, it'll bundle the classic and modern files and generate typings for them. The typings for the classic API aren't fully correct; due to a difference in how tsc and deno resolve modules, tsc can't fetch the full types it needs.